### PR TITLE
Aggiunge banner informativo chiusura segreteria didattica in home page

### DIFF
--- a/components/InfoBanner.jsx
+++ b/components/InfoBanner.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { Icon } from '@iconify/react'
+
+export default function InfoBanner({ message }) {
+  if (!message) return null
+
+  return (
+    <div className="w-full bg-[#1976D2]/5 dark:bg-[#1976D2]/10 border-y border-[#1976D2]/20">
+      <div className="max-w-[1200px] mx-auto px-4 md:px-8 py-2.5 flex items-center justify-center gap-2 text-center">
+        <Icon
+          icon="ph:info"
+          className="text-[#1976D2] dark:text-[#64B5F6] flex-shrink-0"
+          width={18}
+        />
+        <p
+          className="text-xs md:text-sm text-gray-700 dark:text-gray-200"
+          style={{ fontFamily: '"Exo 2", sans-serif' }}
+        >
+          {message}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/components/index.js
+++ b/components/index.js
@@ -30,6 +30,7 @@ export { default as SyntheticLightHero } from './SyntheticLightHero.jsx'
 export { default as NewsArchive } from './NewsArchive.jsx'
 export { default as NewsArchiveHero } from './NewsArchiveHero.jsx'
 export { default as GoogleAnalytics } from './GoogleAnalytics'
+export { default as InfoBanner } from './InfoBanner.jsx'
 
 // Reference:
 // https://sunnysingh.io/blog/javascript-import-from-folder

--- a/pages/index.js
+++ b/pages/index.js
@@ -17,6 +17,7 @@ import {
   Test,
   NewsWall,
   SyntheticLightHero,
+  InfoBanner,
 } from '/components'
 
 import INostriNumeri from '/cc/INostriNumeri'
@@ -197,6 +198,7 @@ export default function Home({ data, movies, elementi }) {
         defaultTag='scuola'
         sponsorImage='/images/home/loghi_sponsor_new.png'
       />
+      <InfoBanner message='Si avvisa che la segreteria didattica è chiusa fino al 23 agosto.' />
       <NewsWall data={data} limit={7} defaultTag='scuola' />
       <a
         href='https://www.donboscoitalia.it/go-beyond-traditional-education/'


### PR DESCRIPTION
## Summary
- Aggiunto un nuovo componente `InfoBanner` (barra discreta, sfondo azzurro tenue coerente con la palette del sito, icona informativa)
- Inserito in home page tra l'hero (`SyntheticLightHero`) e la sezione `NewsWall` con il messaggio: "Si avvisa che la segreteria didattica è chiusa fino al 23 agosto."

## Test plan
- [x] `next build` completato senza errori (186 pagine generate)
- [x] `next lint` sui file modificati: nessun nuovo warning introdotto

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3D6h4WbViK5kZjbKk3Mhg)_